### PR TITLE
posts - Update category of Fermat Spiral post

### DIFF
--- a/_posts/2015/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
+++ b/_posts/2015/2015-01-24-fermat-spirals-vogel-angle-phyllotaxis.md
@@ -2,7 +2,8 @@
 layout: post
 title:  "Processing - Exploring Fermat's Spiral and Vogel's Model using the Golden Angle"
 date:   2015-01-24 12:00:00 -0400
-categories: [processing]
+categories: [posts,sketchbook]
+tags: [processing]
 thumbnail: /sketchbook/processing/spirals/screenshot-01.png
 excerpt: This is a Processing sketch inspired by the Fermat spiral; which is closely related to the arrangement of sunflower seeds (phyllotaxis).
 


### PR DESCRIPTION
Moving it to: 
https://brianhonohan.com/posts/sketcbook/2015/01/24/fermat-spirals-vogel-angle-phyllotaxis.html

With rough plan to have 
`posts/` ... be for top-level posts
`posts/<category>` ... be for repo specific posts, in this case the `sketchbook` repo

And use tags for concepts/topics
